### PR TITLE
Update BasicInfoForm.jsx

### DIFF
--- a/src/components/ui/forms/EditProfile/BasicInfoForm.jsx
+++ b/src/components/ui/forms/EditProfile/BasicInfoForm.jsx
@@ -119,8 +119,8 @@ export default function BasicInfoForm({ freelancer, type, jwt }) {
       searchTerm,
       page,
       additionalVariables: {
-        onsiteZipcodesPage: page,
-        onsiteZipcodesPageSize: 10,
+        onbaseZipcodesPage: page,
+        onbaseZipcodesPageSize: 10,
       },
     });
 
@@ -134,8 +134,8 @@ export default function BasicInfoForm({ freelancer, type, jwt }) {
       searchTerm,
       page,
       additionalVariables: {
-        onsiteCountyPage: page,
-        onsiteCountyPageSize: 10,
+        onsiteCountiesPage: page,
+        onsiteCountiesPageSize: 10,
       },
     });
 


### PR DESCRIPTION
This pull request updates variable names in the `BasicInfoForm` component to fix pagination issues due to false naming of query params. The changes primarily involve renaming keys in the `additionalVariables` object.

### Updates to variable names:

* Renamed `onsiteZipcodesPage` and `onsiteZipcodesPageSize` to `onbaseZipcodesPage` and `onbaseZipcodesPageSize`. (`[src/components/ui/forms/EditProfile/BasicInfoForm.jsxL122-R123](diffhunk://#diff-6165679af4e7a9bc7c4e27b9bdf5ddba8d950aa136b1556beb6647489ed8b0d6L122-R123)`)
* Updated `onsiteCountyPage` and `onsiteCountyPageSize` to `onsiteCountiesPage` and `onsiteCountiesPageSize`. (`[src/components/ui/forms/EditProfile/BasicInfoForm.jsxL137-R138](diffhunk://#diff-6165679af4e7a9bc7c4e27b9bdf5ddba8d950aa136b1556beb6647489ed8b0d6L137-R138)`)