### PR TITLE
ML9-12 Subscription Values - Features

### DIFF
--- a/src/components/ui/ServiceInformation/ServiceInformation.jsx
+++ b/src/components/ui/ServiceInformation/ServiceInformation.jsx
@@ -15,6 +15,7 @@ import SearchableSelect from "../Archives/Inputs/SearchableSelect";
 import { normalizeQuery } from "@/utils/queries";
 import { searchData } from "@/lib/client/operations";
 import SwitchB from "../Archives/Inputs/SwitchB";
+import { subscriptionTypeOptions } from "@/data/global/collections";
 
 export default function ServiceInformation() {
   const {
@@ -226,20 +227,15 @@ export default function ServiceInformation() {
     [setInfo]
   );
 
-  const subscriptionTypeOptions = [
-    { value: "month", label: "Μηνιαία Συνδρομή" },
-    { value: "year", label: "Ετήσια Συνδρομή" },
-  ];
-
   // Format for SearchableSelect component
   const selectedSubscriptionType = info.subscription_type
     ? {
         id: info.subscription_type,
         attributes: {
           label:
-            info.subscription_type === "month"
-              ? "Μηνιαία Συνδρομή"
-              : "Ετήσια Συνδρομή",
+            subscriptionTypeOptions.find(
+              (opt) => opt.value === info.subscription_type
+            )?.label || "Άγνωστο",
         },
       }
     : null;
@@ -487,8 +483,8 @@ export default function ServiceInformation() {
               <div className="mb20 ">
                 <SearchableSelect
                   name="subscription-type"
-                  label="Τύπος Συνδρομής"
-                  labelPlural="τύποι συνδρομής"
+                  label="Πληρωμή"
+                  labelPlural="τύποι πληρωμής"
                   staticOptions={subscriptionTypeOptions}
                   value={selectedSubscriptionType}
                   onSelect={handleSubscriptionTypeSelect}

--- a/src/components/ui/SingleService/Info.jsx
+++ b/src/components/ui/SingleService/Info.jsx
@@ -68,7 +68,13 @@ export default function Info({
             <div className="details">
               <h5 className="title">Συνδρομή</h5>
               <p className="mb-0 text">
-                {subscription_type === "month" ? "Μηνιαία" : "Ετήσια"}
+                {{
+                  month: "Μηνιαία",
+                  year: "Ετήσια",
+                  per_case: "Κατά περίπτωση",
+                  per_hour: "Ανά Ώρα",
+                  per_session: "Ανά Συνεδρία",
+                }[subscription_type] || "Άγνωστο"}
               </p>
             </div>
           </div>

--- a/src/data/global/collections.js
+++ b/src/data/global/collections.js
@@ -162,3 +162,11 @@ export const budgetOptions = [
     slug: "50",
   },
 ];
+
+export const subscriptionTypeOptions = [
+  { value: "month", label: "Μηνιαία Συνδρομή" },
+  { value: "year", label: "Ετήσια Συνδρομή" },
+  { value: "per_case", label: "Κατά περίπτωση" },
+  { value: "per_hour", label: "Ανά Ώρα" },
+  { value: "per_session", label: "Ανά Συνεδρία" },
+];


### PR DESCRIPTION
This pull request refactors how subscription types are handled by centralizing their definitions and improving code maintainability. The changes include moving subscription type options to a shared collection, updating components to use the centralized options, and enhancing the display logic for subscription types.

### Refactoring and centralization of subscription type options:

* [`src/data/global/collections.js`](diffhunk://#diff-7c17b21bbc65b73e8b4a84b2c3c28e5404134169b1c58411573a14abfa9636b5R165-R172): Added a new `subscriptionTypeOptions` array to centralize the definitions of subscription types, including their values and labels.

* [`src/components/ui/ServiceInformation/ServiceInformation.jsx`](diffhunk://#diff-7307446749dd879d240664a06fa051cbb0768f95a3dcd1518f7a536a6cd4b0b7R18): Removed the inline definition of `subscriptionTypeOptions` and replaced it with the imported centralized `subscriptionTypeOptions` from the shared collection. Updated logic to dynamically find the label for the selected subscription type using the centralized options. [[1]](diffhunk://#diff-7307446749dd879d240664a06fa051cbb0768f95a3dcd1518f7a536a6cd4b0b7R18) [[2]](diffhunk://#diff-7307446749dd879d240664a06fa051cbb0768f95a3dcd1518f7a536a6cd4b0b7L229-R238)

### Updates to subscription type display and labels:

* [`src/components/ui/ServiceInformation/ServiceInformation.jsx`](diffhunk://#diff-7307446749dd879d240664a06fa051cbb0768f95a3dcd1518f7a536a6cd4b0b7L490-R487): Updated the `SearchableSelect` component labels from "Τύπος Συνδρομής" to "Πληρωμή" and adjusted the plural label accordingly.

* [`src/components/ui/SingleService/Info.jsx`](diffhunk://#diff-1133e13a09d477e147082a1a5fec86d32a3eab119eed29b4a4177df079294864L71-R77): Enhanced the logic for displaying subscription types by using a mapping object that supports additional types such as "Κατά περίπτωση," "Ανά Ώρα," and "Ανά Συνεδρία," with a fallback to "Άγνωστο" for unknown types.