### PR TITLE
ML9-31 Profile archives per page - Fixes #228

### DIFF
--- a/src/lib/graphql/queries/main/freelancer/index.js
+++ b/src/lib/graphql/queries/main/freelancer/index.js
@@ -145,7 +145,7 @@ const FREELANCERS_ARCHIVE = gql`
         ]
       }
       sort: $sort
-      pagination: { page: $page, pageSize: 20 }
+      pagination: { page: $page, pageSize: 21 }
     ) {
       data {
         id
@@ -203,7 +203,7 @@ const FREELANCERS_ARCHIVE_WITH_SKILLS = gql`
         ]
       }
       sort: $sort
-      pagination: { page: $page, pageSize: 20 }
+      pagination: { page: $page, pageSize: 21 }
     ) {
       data {
         id


### PR DESCRIPTION
This pull request makes a small adjustment to the pagination settings in two GraphQL queries within the `src/lib/graphql/queries/main/freelancer/index.js` file. The `pageSize` parameter has been increased from 20 to 21 in both queries.

Changes to pagination:

* [`const FREELANCERS_ARCHIVE`](diffhunk://#diff-c44a7bf47d1c8f37c7887958f4e5f3413d84758ed898c48671e67398c1d2fd7dL148-R148): Updated the `pageSize` parameter in the pagination object from 20 to 21.
* [`const FREELANCERS_ARCHIVE_WITH_SKILLS`](diffhunk://#diff-c44a7bf47d1c8f37c7887958f4e5f3413d84758ed898c48671e67398c1d2fd7dL206-R206): Updated the `pageSize` parameter in the pagination object from 20 to 21.