### PR TITLE
ML11-29 Best Practices #274

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -30,6 +30,7 @@ const nextConfig = {
     minimumCacheTTL: 2678400, // 31 days
     remotePatterns: [
       {
+        protocol: 'https',
         hostname: 'res.cloudinary.com',
       },
     ],


### PR DESCRIPTION
Specified the 'https' protocol for the Cloudinary hostname in the remotePatterns array to ensure correct image loading and improve configuration clarity.