### PR TITLE
ML11-29 Add CSP to force HTTPS and fix mixed content issue #274

### DIFF
--- a/src/middlewares/withHeaders.js
+++ b/src/middlewares/withHeaders.js
@@ -20,6 +20,9 @@ export const withHeaders = (next) => {
     responseHeaders.set('X-XSS-Protection', '1; mode=block');
     responseHeaders.set('Referrer-Policy', 'strict-origin-when-cross-origin');
 
+    // Force HTTPS for all requests - THIS FIXES THE MIXED CONTENT ISSUE
+    responseHeaders.set('Content-Security-Policy', 'upgrade-insecure-requests');
+
     return NextResponse.next({
       headers: responseHeaders,
       request: {


### PR DESCRIPTION
Added 'Content-Security-Policy: upgrade-insecure-requests' header in withHeaders middleware to ensure all requests are upgraded to HTTPS, resolving mixed content problems.